### PR TITLE
feat:  Add configuration allowItemToFail to poll mode, and add a gate…

### DIFF
--- a/src/main/kotlin/net/djvk/fireflyPlaidConnector2/sync/PolledSyncRunner.kt
+++ b/src/main/kotlin/net/djvk/fireflyPlaidConnector2/sync/PolledSyncRunner.kt
@@ -41,7 +41,7 @@ class PolledSyncRunner(
     private val cursorFileDirectoryPath: String,
     @Value("\${fireflyPlaidConnector2.plaid.batchSize}")
     private val plaidBatchSize: Int,
-    @Value("\${fireflyPlaidConnector2.polled.allowItemToFail}")
+    @Value("\${fireflyPlaidConnector2.polled.allowItemToFail:false}")
     private val allowItemToFail: Boolean,
 
     private val plaidApiWrapper: PlaidApiWrapper,

--- a/src/main/kotlin/net/djvk/fireflyPlaidConnector2/sync/PolledSyncRunner.kt
+++ b/src/main/kotlin/net/djvk/fireflyPlaidConnector2/sync/PolledSyncRunner.kt
@@ -1,8 +1,6 @@
 package net.djvk.fireflyPlaidConnector2.sync
 
-import io.ktor.client.call.*
 import io.ktor.client.plugins.*
-import io.ktor.http.*
 import kotlinx.coroutines.*
 import net.djvk.fireflyPlaidConnector2.api.firefly.apis.TransactionsApi
 import net.djvk.fireflyPlaidConnector2.api.firefly.models.TransactionRead
@@ -16,7 +14,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 import java.time.LocalDate
-import java.util.Collections
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.io.path.Path
 import kotlin.time.Duration.Companion.minutes
@@ -85,13 +82,11 @@ class PolledSyncRunner(
                                 ?: continue@cursorCatchupLoop
                         logger.debug(
                             "Received initial batch of sync updates for access token $accessToken. " +
-                                    "Updating cursor map to next cursor: ${response?.nextCursor}"
+                                    "Updating cursor map to next cursor: ${response.nextCursor}"
                         )
-
-                        if (response.nextCursor.isNotEmpty()) {
+                        if (response.nextCursor.isNotBlank()) {
                             cursorMap[accessToken] = response.nextCursor
                         }
-
                     } while (response.hasMore)
                 }
                 writeCursorMap(cursorMap)
@@ -163,9 +158,7 @@ class PolledSyncRunner(
                                 cursorMap[accessToken],
                                 plaidBatchSize
                             ) ?: continue@accessTokenLoop
-
                             cursorMap[accessToken] = response.nextCursor
-
                             logger.debug(
                                 "Received batch of sync updates for access token $accessToken: " +
                                         "${response.added.size} created; ${response.modified.size} updated; " +

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,6 +33,9 @@ fireflyPlaidConnector2:
     # This path needs to be writeable by the application's user and needs to be persistent. If you're using Docker,
     #   you may want to use a volume or bind mount for this so that cursor state is persisted between runs.
     cursorFileDirectoryPath: persistence/
+    # Configuration element specifying whether the remainder of the poll sync session should continue if one item
+    # has failed to fetch from PLaid for any reason.
+    allowItemToFail: false
   batch:
     # The number of days in the past to pull data for.
     maxSyncDays: 5

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,7 +34,7 @@ fireflyPlaidConnector2:
     #   you may want to use a volume or bind mount for this so that cursor state is persisted between runs.
     cursorFileDirectoryPath: persistence/
     # Configuration element specifying whether the remainder of the poll sync session should continue if one item
-    # has failed to fetch from PLaid for any reason.
+    # has failed to fetch from Plaid for any reason.
     allowItemToFail: false
   batch:
     # The number of days in the past to pull data for.


### PR DESCRIPTION
… around each access_token/item update to allow it to fail without failing the entire poll sync

Maintains backward compatibility with existing behaviour with default of `false`.  

Addressed #91 