### PR TITLE
enums as well as properties

### DIFF
--- a/src/main/kotlin/net/djvk/fireflyPlaidConnector2/api/plaid/infrastructure/ApiClient.kt
+++ b/src/main/kotlin/net/djvk/fireflyPlaidConnector2/api/plaid/infrastructure/ApiClient.kt
@@ -60,6 +60,7 @@ open class ApiClient(
             registerModule(JavaTimeModule())
             configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
             configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+            configure(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL, true)
         }
         protected val UNSAFE_HEADERS = listOf<String>()
     }


### PR DESCRIPTION
There's a discussion [here](https://github.com/dvankley/firefly-plaid-connector-2/issues/104#issue-2387257944) ... but to summarize:

 - The config FAIL_ON_UNKNOWN_PROPERTIES handles unknown *Properties*
 - Unknown enums cause an exception unless either READ_UNKNOWN_ENUM_VALUES_AS_NULL or READ_UNKNOWN_ENUM_VALUES_AS_DEFAULT is specified.