### PR TITLE
Firefly Transaction Formatting Enhancements

### DIFF
--- a/src/main/kotlin/net/djvk/fireflyPlaidConnector2/config/properties/TransactionStyleConfig.kt
+++ b/src/main/kotlin/net/djvk/fireflyPlaidConnector2/config/properties/TransactionStyleConfig.kt
@@ -1,0 +1,8 @@
+package net.djvk.fireflyPlaidConnector2.config.properties
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "firefly-plaid-connector2")
+data class TransactionStyleConfig(
+    val descriptionExpression: String? = null,
+)

--- a/src/main/kotlin/net/djvk/fireflyPlaidConnector2/sync/BatchSyncRunner.kt
+++ b/src/main/kotlin/net/djvk/fireflyPlaidConnector2/sync/BatchSyncRunner.kt
@@ -209,7 +209,7 @@ class BatchSyncRunner(
                 }
 
                 val earliestTimestamp = txs.fold(OffsetDateTime.now()) { acc, tx ->
-                    val ts = converter.getTxTimestamp(tx)
+                    val ts = converter.getTxPostedTimestamp(tx)
                     if (ts < acc) {
                         ts
                     } else {

--- a/src/main/kotlin/net/djvk/fireflyPlaidConnector2/transactions/TransactionConverter.kt
+++ b/src/main/kotlin/net/djvk/fireflyPlaidConnector2/transactions/TransactionConverter.kt
@@ -1,5 +1,6 @@
 package net.djvk.fireflyPlaidConnector2.transactions
 
+import io.ktor.http.*
 import net.djvk.fireflyPlaidConnector2.api.firefly.apis.FireflyTransactionId
 import net.djvk.fireflyPlaidConnector2.api.firefly.models.TransactionRead
 import net.djvk.fireflyPlaidConnector2.api.firefly.models.TransactionSplit
@@ -436,6 +437,15 @@ class TransactionConverter(
     ): FireflyTransactionDto {
         val postedTime = getTxPostedTimestamp(tx)
         val authorizedTime = getTxAuthorizedTimestamp(tx)
+        val externalUrl = if (tx.website != null) {
+            // Plaid does not provide the protocol in the string. Firefly requires a protocol.
+            URLBuilder(
+                protocol = URLProtocol.HTTPS,
+                host = tx.website,
+            ).buildString()
+        } else {
+            null
+        }
         val split = TransactionSplit(
             getFireflyTransactionDtoType(tx, isPair),
             // Plaid's guidance on using authorized date vs posted date:
@@ -461,6 +471,9 @@ class TransactionConverter(
             destinationId = destinationId,
             destinationName = destinationName,
             tags = getFireflyCategoryTags(tx),
+            latitude = tx.location.lat,
+            longitude = tx.location.lon,
+            externalUrl = externalUrl,
             externalId = FireflyTransactionExternalIdIndexer.getExternalId(tx.transactionId),
             order = 0,
             reconciled = false,

--- a/src/main/kotlin/net/djvk/fireflyPlaidConnector2/transactions/TransactionConverter.kt
+++ b/src/main/kotlin/net/djvk/fireflyPlaidConnector2/transactions/TransactionConverter.kt
@@ -128,7 +128,7 @@ class TransactionConverter(
 
         return try {
             val parser = SpelExpressionParser()
-            val context = StandardEvaluationContext(tx)
+            val context = StandardEvaluationContext(FormattingContext(tx))
 
             // Provide #defaultDescription with the default description
             context.setVariable("merchantAndDescription", defaultDesc)
@@ -582,3 +582,10 @@ class TransactionConverter(
         }
     }
 }
+
+/**
+ * Container data class for the values passed into the SpEL evaluator context. Although there is currently only one
+ * value here, wrapping that value will make it much easier in the future if we ever want to make other objects
+ * available during SpEL evaluation.
+ */
+data class FormattingContext(val transaction: PlaidTransaction)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -74,19 +74,22 @@ fireflyPlaidConnector2:
   #      set to the legacy "name" field.
   # Although we do our best to fall back to the default description format if you specify an invalid expression, this
   # can be a little difficult to use if you're unfamiliar with the format. Here are a few examples to get you started.
-  #   * "name + ': ' + originalDescription" - This is a simple demonstration of how to access fields from the Plaid
-  #       transaction and link them together. Notice how Plaid fields are NOT prefixed with "#", and you must use + and
-  #       single quotes to concatenate those values with string literals.
-  #   * "merchantName + ': ' + originalDescription" - This is an example of what NOT to do. If you look at the Plaid
-  #       documentation you'll see that merchant_name is nullable. When we get a transaction where the merchant_name
-  #       is not set, you'll get a description like "null: Your Original Description". If you don't want "null" showing
-  #       up like that you'll need to look at the next few examples for tips on avoiding it.
-  #   * "merchantName?:name + ': ' + originalDescription" - This demonstrates use of the Elvis operator to fallback to
-  #       another value if the first is null. Note that "#merchantNameWithFallback" is the same as "merchantName?:name".
-  #   * "originalDescription ?: merchantName ?: name" - This demonstrates chaining multiple Elvis operators together.
-  #       This is a recommended expression if you want to have expressive descriptions with minimal redundancy.
-  #   * "#merchantAndDescription + (amount > 100 ? ' (expensive!)' : '')" - This will append (expensive!) at the end of
-  #       the description for transactions above a certain amount. This demonstrates usage of the SpEL ternary operator.
+  #   * "transaction.name + ': ' + transaction.originalDescription" - This is a simple demonstration of how to access
+  #       fields from the Plaid transaction and link them together. Notice how Plaid fields are NOT prefixed with "#",
+  #       and you must use + and single quotes to concatenate those values with string literals.
+  #   * "transaction.merchantName + ': ' + transaction.originalDescription" - This is an example of what NOT to do. If
+  #       you look at the Plaiddocumentation you'll see that merchant_name is nullable. When we get a transaction where
+  #       the merchant_nameis not set, you'll get a description like "null: Your Original Description". If you don't
+  #       want "null" showing up like that you'll need to look at the next few examples for tips on avoiding it.
+  #   * "transaction.merchantName?:transaction.name + ': ' + transaction.originalDescription" - This demonstrates use of
+  #       the Elvis operator to fallback to another value if the first is null. Note that "#merchantNameWithFallback" is
+  #       the same as "merchantName?:name".
+  #   * "transaction.originalDescription ?: transaction.merchantName ?: transaction.name" - This demonstrates chaining
+  #       multiple Elvis operators together. This is a recommended expression if you want to have expressive
+  #       descriptions with minimal redundancy.
+  #   * "#merchantAndDescription + (transaction.amount > 100 ? ' (expensive!)' : '')" - This will append the string
+  #       "(expensive!)" at the end of the description for transactions above a certain amount. This demonstrates usage
+  #       of the SpEL ternary operator.
   # As some of the expression syntax can conflict with YAML syntax, it's important to explicitly quote this value.
 #  descriptionExpression: "#merchantAndDescription"
   # Transaction categorization configuration (optional, defaults to disable categorization)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,34 @@ fireflyPlaidConnector2:
     batchSize: 100
     # The number of times to retry a failed API call.
     maxRetries: 3
+  # Customize your Firefly transaction description string. When descriptionExpression is omitted or set to an empty
+  # string, the description will be formatted as something like "merchantName: originalDescription".
+  # The expressions are formed as Spring Expression Language (SpEL).
+  # https://docs.spring.io/spring-framework/docs/3.0.x/reference/expressions.html
+  # You should be able to access any of the fields seen under the "added" section of the Plaid sync transactions docs.
+  # Note that the Plaid field names must be converted from snake_case to camelCase.
+  # https://plaid.com/docs/api/products/transactions/#transactions-sync-response-added
+  # Additionally, we set a few special variables that are prefixed with a "#". Those variables are:
+  #  * #merchantAndDescription : The default description value that we use if you don't set any expression at all.
+  #  * #merchantNameWithFallback : This will be set to the Plaid "merchant" field, if available, otherwise it will be
+  #      set to the legacy "name" field.
+  # Although we do our best to fall back to the default description format if you specify an invalid expression, this
+  # can be a little difficult to use if you're unfamiliar with the format. Here are a few examples to get you started.
+  #   * "name + ': ' + originalDescription" - This is a simple demonstration of how to access fields from the Plaid
+  #       transaction and link them together. Notice how Plaid fields are NOT prefixed with "#", and you must use + and
+  #       single quotes to concatenate those values with string literals.
+  #   * "merchantName + ': ' + originalDescription" - This is an example of what NOT to do. If you look at the Plaid
+  #       documentation you'll see that merchant_name is nullable. When we get a transaction where the merchant_name
+  #       is not set, you'll get a description like "null: Your Original Description". If you don't want "null" showing
+  #       up like that you'll need to look at the next few examples for tips on avoiding it.
+  #   * "merchantName?:name + ': ' + originalDescription" - This demonstrates use of the Elvis operator to fallback to
+  #       another value if the first is null. Note that "#merchantNameWithFallback" is the same as "merchantName?:name".
+  #   * "originalDescription ?: merchantName ?: name" - This demonstrates chaining multiple Elvis operators together.
+  #       This is a recommended expression if you want to have expressive descriptions with minimal redundancy.
+  #   * "#merchantAndDescription + (amount > 100 ? ' (expensive!)' : '')" - This will append (expensive!) at the end of
+  #       the description for transactions above a certain amount. This demonstrates usage of the SpEL ternary operator.
+  # As some of the expression syntax can conflict with YAML syntax, it's important to explicitly quote this value.
+#  descriptionExpression: "#merchantAndDescription"
   # Transaction categorization configuration (optional, defaults to disable categorization)
   # Plaid currently supplies two types of categorization information https://plaid.com/blog/transactions-categorization-taxonomy/
   # The current plan is to ignore the old categorization type because the new type (transaction.personalFinanceCategory)

--- a/src/test/kotlin/net/djvk/fireflyPlaidConnector2/lib/FireflyFixtures.kt
+++ b/src/test/kotlin/net/djvk/fireflyPlaidConnector2/lib/FireflyFixtures.kt
@@ -65,7 +65,7 @@ object FireflyFixtures {
         sepaBatchId: String? = null,
         interestDate: java.time.OffsetDateTime? = null,
         bookDate: java.time.OffsetDateTime? = null,
-        processDate: java.time.OffsetDateTime? = null,
+        processDate: java.time.OffsetDateTime? = defaultOffsetNow,
         dueDate: java.time.OffsetDateTime? = null,
         paymentDate: java.time.OffsetDateTime? = null,
         invoiceDate: java.time.OffsetDateTime? = null,

--- a/src/test/kotlin/net/djvk/fireflyPlaidConnector2/lib/PlaidFixtures.kt
+++ b/src/test/kotlin/net/djvk/fireflyPlaidConnector2/lib/PlaidFixtures.kt
@@ -58,7 +58,12 @@ object PlaidFixtures {
         originalDescription: String? = null,
         merchantName: String? = null,
         checkNumber: String? = null,
-        personalFinanceCategory: PersonalFinanceCategory? = PersonalFinanceCategoryEnum.TRANSFER_OUT_ACCOUNT_TRANSFER.toPersonalFinanceCategory()
+        personalFinanceCategory: PersonalFinanceCategory? = PersonalFinanceCategoryEnum.TRANSFER_OUT_ACCOUNT_TRANSFER.toPersonalFinanceCategory(),
+        website: String? = null,
+        logoUrl: String? = null,
+        personalFinanceCategoryIconUrl: String? = null,
+        counterparties: List<TransactionCounterparty>? = null,
+        merchantEntityId: String? = null,
     ): Transaction {
         return Transaction(
             pendingTransactionId = pendingTransactionId,
@@ -85,6 +90,11 @@ object PlaidFixtures {
             merchantName = merchantName,
             checkNumber = checkNumber,
             personalFinanceCategory = personalFinanceCategory,
+            website = website,
+            logoUrl = logoUrl,
+            personalFinanceCategoryIconUrl = personalFinanceCategoryIconUrl,
+            counterparties = counterparties,
+            merchantEntityId = merchantEntityId,
         )
     }
 

--- a/src/test/kotlin/net/djvk/fireflyPlaidConnector2/sync/BatchSyncRunnerTest.kt
+++ b/src/test/kotlin/net/djvk/fireflyPlaidConnector2/sync/BatchSyncRunnerTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.runBlocking
 import net.djvk.fireflyPlaidConnector2.api.plaid.models.TransactionsGetResponse
 import net.djvk.fireflyPlaidConnector2.config.AccountConfig
 import net.djvk.fireflyPlaidConnector2.config.properties.AccountConfigs
+import net.djvk.fireflyPlaidConnector2.config.properties.TransactionStyleConfig
 import net.djvk.fireflyPlaidConnector2.lib.*
 import net.djvk.fireflyPlaidConnector2.transactions.TransactionConverter
 import org.assertj.core.api.Assertions.assertThat
@@ -38,6 +39,7 @@ internal class BatchSyncRunnerTest {
                 primaryCategoryPrefix = "primary-",
                 enableDetailedCategorization = true,
                 detailedCategoryPrefix = "detailed-",
+                txStyle = TransactionStyleConfig(),
             )
 
             return BatchSyncRunner(

--- a/src/test/kotlin/net/djvk/fireflyPlaidConnector2/transactions/TransactionConverterTest.kt
+++ b/src/test/kotlin/net/djvk/fireflyPlaidConnector2/transactions/TransactionConverterTest.kt
@@ -700,7 +700,7 @@ internal class TransactionConverterTest {
             return listOf(
                 Arguments.of(
                     "Expression can access fields from the Plaid transaction",
-                    TransactionStyleConfig("name + ': ' + originalDescription"),
+                    TransactionStyleConfig("transaction.name + ': ' + transaction.originalDescription"),
                     "Name", // Plaid "name"
                     "Merchant", // Plaid "merchantName"
                     "Desc", // Plaid "originalDescription"
@@ -708,7 +708,7 @@ internal class TransactionConverterTest {
                 ),
                 Arguments.of(
                     "Demonstration of the ternary operator to conditionally append a string",
-                    TransactionStyleConfig("#merchantAndDescription + (amount > 100 ? ' (expensive!)' : '')"),
+                    TransactionStyleConfig("#merchantAndDescription + (transaction.amount > 100 ? ' (expensive!)' : '')"),
                     "Name", // Plaid "name"
                     "Merchant", // Plaid "merchantName"
                     "Desc", // Plaid "originalDescription"
@@ -716,7 +716,7 @@ internal class TransactionConverterTest {
                 ),
                 Arguments.of(
                     "Demonstration of the Elvis operator to fallback to a non-null value",
-                    TransactionStyleConfig("merchantName?:name + ': ' + originalDescription"),
+                    TransactionStyleConfig("transaction.merchantName?:transaction.name + ': ' + transaction.originalDescription"),
                     "Name", // Plaid "name"
                     null, // Plaid "merchantName"
                     "Desc", // Plaid "originalDescription"
@@ -724,7 +724,7 @@ internal class TransactionConverterTest {
                 ),
                 Arguments.of(
                     "Demonstration of multiple chained elvis operators",
-                    TransactionStyleConfig("originalDescription ?: merchantName ?: name"),
+                    TransactionStyleConfig("transaction.originalDescription ?: transaction.merchantName ?: transaction.name"),
                     "Name", // Plaid "name"
                     null, // Plaid "merchantName"
                     null, // Plaid "originalDescription"
@@ -796,7 +796,7 @@ internal class TransactionConverterTest {
                 ),
                 Arguments.of(
                     "if the expression references a null field, the string \"null\" is used",
-                    TransactionStyleConfig("merchantName + ': ' + originalDescription"),
+                    TransactionStyleConfig("transaction.merchantName + ': ' + transaction.originalDescription"),
                     "unused", // Plaid "name"
                     null, // Plaid "merchantName"
                     "Desc", // Plaid "originalDescription"
@@ -804,7 +804,7 @@ internal class TransactionConverterTest {
                 ),
                 Arguments.of(
                     "if the expression results in null, the default description is used",
-                    TransactionStyleConfig("merchantName"),
+                    TransactionStyleConfig("transaction.merchantName"),
                     "Name", // Plaid "name"
                     null, // Plaid "merchantName"
                     "Desc", // Plaid "originalDescription"


### PR DESCRIPTION
This PR enhances the Firefly transactions written by firefly-plaid-connector-2 in the following ways:

1. Populate the Firefly externalUrl, latitude, and longitude fields, if the corresponding Plaid fields were present.
2. Prefer Plaid's `authorizedDatetime` over the `datetime` field. If `authorizedDatetime` is not available, we will fallback to `datetime`. And `datetime` will also still be preserved as the Firefly `processDate` field. My motivation for this comes from the [Plaid documentation](https://plaid.com/docs/api/products/transactions/#transactionssync), which states: *"The authorized_date, when available, is generally preferable to use over the date field for posted transactions, as it will generally represent the date the user actually made the transaction."*
3. Resolves https://github.com/dvankley/firefly-plaid-connector-2/issues/109 by allowing for customization of the Firefly description string. The README is updated with explanation of the formatting and examples. The behavior of each example from the README is also demonstrated via unit tests. I left the default configuration set to the current format, but I do think it might make sense to update the default. I have been using the expression `"originalDescription ?: merchantName ?: name"` in my stack for the last few weeks and think it would make a sane default.